### PR TITLE
fix(migrations): use correct table name for rollback of migrations

### DIFF
--- a/database/migrations/create_backpack_async_import_exports_table.php.stub
+++ b/database/migrations/create_backpack_async_import_exports_table.php.stub
@@ -31,6 +31,6 @@ class CreateBackpackAsyncImportExportsTable extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('exports');
+        Schema::dropIfExists('import_exports');
     }
 }


### PR DESCRIPTION
Noticed that the rollback of the migrations was using a different table name