### PR TITLE
Fix export button text content of HasExportButton trait

### DIFF
--- a/resources/views/buttons/export.blade.php
+++ b/resources/views/buttons/export.blade.php
@@ -3,7 +3,7 @@
     @php($url = url($crud->route . '/' . config('backpack-async-import-export.admin_export_route')))
     @foreach($exports as $export => $exportsName)
         <a href="{{ $url }}?{{ Thomascombe\BackpackAsyncExport\Http\Controllers\Admin\Interfaces\MultiExportableCrud::QUERY_PARAM }}={{ $export }}" class="btn btn-secondary">
-            <i class="la la-download"></i> @lang('backpack-async-export::export.buttons.exports') }}@if (!empty($exportsName)) ({{ $exportsName }})@endif
+            <i class="la la-download"></i> @lang('backpack-async-export::export.buttons.exports') @if (!empty($exportsName)) ({{ $exportsName }})@endif
         </a>
     @endforeach
 @endif


### PR DESCRIPTION
Noticed that `}}` was present in the button text of the `HasExportButton` trait